### PR TITLE
腾讯云自动部署

### DIFF
--- a/.github/workflows/deploy_tc.yml
+++ b/.github/workflows/deploy_tc.yml
@@ -1,0 +1,39 @@
+name: Deploy to Tencent Cloud
+on:
+  workflow_run:
+    workflows:
+      - Build Docker Image
+    types:
+      - completed
+    branches:
+      - release
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: copy files via ssh key
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: "${{ secrets.TENCENT_CLOUD_HOST }}"
+          username: "${{ secrets.TENCENT_CLOUD_USERNAME }}"
+          key: ${{ secrets.TENCENT_SECRET_KEY }}
+          source: "docker-compose.yml, prometheus.yml, .env.pro"
+          target: "~/dotenv/"
+
+      - name: Deploy to Tencent Cloud
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: "${{ secrets.TENCENT_CLOUD_HOST }}"
+          username: "${{ secrets.TENCENT_CLOUD_USERNAME }}"
+          key: ${{ secrets.TENCENT_SECRET_KEY }}
+          script: |
+            cd ~/dotenv
+            cp .env.pro .env
+            docker-compose pull
+            docker-compose up --force-recreate -d
+            docker image prune -f


### PR DESCRIPTION
1. 项目设置里添加 Repository secrets：
<img width="897" alt="Screenshot 2024-04-10 at 02 14 09" src="https://github.com/tonsh/doenv/assets/848371/8c4530d6-be56-4b22-9776-0d3be91156e3">

参考：[腾讯云自动部署](https://cloud.tencent.com/document/product/583/71690)

2. scp 目标文件至远程服务器
3. ssh 执行远程脚本（docker-compose 拉取最新镜像，强制重建容器，清理无用镜像）
4. 使用 `workflow_run` 触发自动部署工作流（workflow）的执行。
    workflow_run 有个需要注意的问题, 调试时需将调试分支设置为“默认分支”，否则工作流不会触发；
    `Note: This event will only trigger a workflow run if the workflow file is on the default branch.`

   参考:  
  [workflow-run 文档](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
   讨论：`https://github.com/orgs/community/discussions/25288#discussioncomment-3247301`